### PR TITLE
feat: including relative filename and dirname with `require.resolve.

### DIFF
--- a/internal/snap_printer/snap_handle_ecall.go
+++ b/internal/snap_printer/snap_handle_ecall.go
@@ -2,6 +2,7 @@ package snap_printer
 
 import "github.com/evanw/esbuild/internal/js_ast"
 
+// require.resolve
 func (p *printer) handleRequireResolve(ecall *js_ast.ECall) (handled bool) {
 	switch tgt := ecall.Target.Data.(type) {
 	case *js_ast.EDot:
@@ -24,7 +25,7 @@ func (p *printer) handleRequireResolve(ecall *js_ast.ECall) (handled bool) {
 	return false
 }
 
-// require.resolve
+// NOTE: currently not used as when bundling the ERequireResolve case is hit instead
 func (p *printer) handleECall(ecall *js_ast.ECall) (handled bool) {
 	return p.handleRequireResolve(ecall)
 }

--- a/internal/snap_printer/snap_handle_ecall.go
+++ b/internal/snap_printer/snap_handle_ecall.go
@@ -1,0 +1,43 @@
+package snap_printer
+
+import "github.com/evanw/esbuild/internal/js_ast"
+
+func (p *printer) handleRequireResolve(ecall *js_ast.ECall) (handled bool) {
+	switch tgt := ecall.Target.Data.(type) {
+	case *js_ast.EDot:
+		if tgt.Name != "resolve" {
+			return false
+		}
+		// Ensure it is a `require.resolve`
+		switch reqTgt := tgt.Target.Data.(type) {
+		case *js_ast.EIdentifier:
+			if p.renamer.IsRequire(reqTgt.Ref) {
+				// Cannot rewrite non-custom require.resolve
+				if len(ecall.Args) > 1 {
+					return false
+				}
+				p._printRequireResolve(&ecall.Args[0])
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// require.resolve
+func (p *printer) handleECall(ecall *js_ast.ECall) (handled bool) {
+	return p.handleRequireResolve(ecall)
+}
+
+// -----------------
+// Printers
+// -----------------
+
+func (p *printer) _printRequireResolve(request *js_ast.Expr) {
+	p.print("require.resolve(")
+	p.printExpr(*request, js_ast.LComma, 0)
+	// NOTE: more info about __dirname2/__dirname inside
+	// internal/snap_renamer/snap_renamer.go (functionWrapperForAbsPath)
+	p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
+	p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
+}

--- a/internal/snap_printer/snap_printer.go
+++ b/internal/snap_printer/snap_printer.go
@@ -1201,34 +1201,32 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 			}
 		}
 
-		if handled := p.handleECall(e); !handled {
-			// We don't ever want to accidentally generate a direct eval expression here
-			p.callTarget = e.Target.Data
-			if !e.IsDirectEval && p.isUnboundEvalIdentifier(e.Target) {
-				if p.options.RemoveWhitespace {
-					p.print("(0,")
-				} else {
-					p.print("(0, ")
-				}
-				p.printExpr(e.Target, js_ast.LPostfix, 0)
-				p.print(")")
+		// We don't ever want to accidentally generate a direct eval expression here
+		p.callTarget = e.Target.Data
+		if !e.IsDirectEval && p.isUnboundEvalIdentifier(e.Target) {
+			if p.options.RemoveWhitespace {
+				p.print("(0,")
 			} else {
-				p.printExpr(e.Target, js_ast.LPostfix, targetFlags)
+				p.print("(0, ")
 			}
-
-			if e.OptionalChain == js_ast.OptionalChainStart {
-				p.print("?.")
-			}
-			p.print("(")
-			for i, arg := range e.Args {
-				if i != 0 {
-					p.print(",")
-					p.printSpace()
-				}
-				p.printExpr(arg, js_ast.LComma, 0)
-			}
+			p.printExpr(e.Target, js_ast.LPostfix, 0)
 			p.print(")")
-		} // end handleECall
+		} else {
+			p.printExpr(e.Target, js_ast.LPostfix, targetFlags)
+		}
+
+		if e.OptionalChain == js_ast.OptionalChainStart {
+			p.print("?.")
+		}
+		p.print("(")
+		for i, arg := range e.Args {
+			if i != 0 {
+				p.print(",")
+				p.printSpace()
+			}
+			p.printExpr(arg, js_ast.LComma, 0)
+		}
+		p.print(")")
 
 		if wrap {
 			p.print(")")

--- a/internal/snap_printer/snap_printer.go
+++ b/internal/snap_printer/snap_printer.go
@@ -1248,6 +1248,8 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 		p.printSpaceBeforeIdentifier()
 		p.print("require.resolve(")
 		p.printQuotedUTF8(p.importRecords[e.ImportRecordIndex].Path.Text, true /* allowBacktick */)
+		p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
+		p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
 		p.print(")")
 		if wrap {
 			p.print(")")

--- a/internal/snap_printer/snap_printer_test.go
+++ b/internal/snap_printer/snap_printer_test.go
@@ -1308,38 +1308,6 @@ module.exports = exports = require("./lib/_stream_readable.js");
 `, ReplaceAll)
 }
 
-func TestRequireResolveRewrite(t *testing.T) {
-	expectPrinted(t, `
-const fooPath = require.resolve('./foo')
-`, `
-const fooPath = require.resolve("./foo", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
-`, ReplaceAll)
-
-	expectPrinted(t, `
-require.resolve('./foo')
-`, `
-require.resolve("./foo", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
-`, ReplaceAll)
-
-	expectPrinted(t, `
-delete require.cache[require.resolve('./fixtures/sync-deps.js')]
-`, `
-delete require.cache[require.resolve("./fixtures/sync-deps.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)];
-`, ReplaceAll)
-
-	expectPrinted(t, `
-function toBeResolved(prefix) {
-  return prefix + 'foo'
-}
-require.resolve(toBeResolved('./'))
-`, `
-function toBeResolved(prefix) {
-  return prefix + "foo";
-}
-require.resolve(toBeResolved("./"), (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
-`, ReplaceAll)
-}
-
 func TestDebug(t *testing.T) {
 	debugPrinted(t, `
 function runTests() {

--- a/internal/snap_printer/snap_printer_test.go
+++ b/internal/snap_printer/snap_printer_test.go
@@ -1308,9 +1308,42 @@ module.exports = exports = require("./lib/_stream_readable.js");
 `, ReplaceAll)
 }
 
+func TestRequireResolveRewrite(t *testing.T) {
+	expectPrinted(t, `
+const fooPath = require.resolve('./foo')
+`, `
+const fooPath = require.resolve("./foo", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
+`, ReplaceAll)
+
+	expectPrinted(t, `
+require.resolve('./foo')
+`, `
+require.resolve("./foo", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
+`, ReplaceAll)
+
+	expectPrinted(t, `
+delete require.cache[require.resolve('./fixtures/sync-deps.js')]
+`, `
+delete require.cache[require.resolve("./fixtures/sync-deps.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)];
+`, ReplaceAll)
+
+	expectPrinted(t, `
+function toBeResolved(prefix) {
+  return prefix + 'foo'
+}
+require.resolve(toBeResolved('./'))
+`, `
+function toBeResolved(prefix) {
+  return prefix + "foo";
+}
+require.resolve(toBeResolved("./"), (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
+`, ReplaceAll)
+}
+
 func TestDebug(t *testing.T) {
 	debugPrinted(t, `
-const { v4: uuidv4 } = require('uuid')
-var x = uuidv4()
+function runTests() {
+	delete require.cache[require.resolve("./fixtures/sync-deps.js")];
+}
 `, ReplaceAll)
 }

--- a/internal/snap_renamer/snap_renamer.go
+++ b/internal/snap_renamer/snap_renamer.go
@@ -232,31 +232,31 @@ func (r *SnapRenamer) IsUnwrappable(ref js_ast.Ref) bool {
 	if symbol.Kind == js_ast.SymbolUnbound {
 		return true
 	}
-	return r.isExportSymbol(symbol)
+	return r.isSymbolNamed(symbol, "exports")
 }
 
-func (r *SnapRenamer) isExportSymbol(symbol *js_ast.Symbol) bool {
+func (r *SnapRenamer) isSymbolNamed(symbol *js_ast.Symbol, name string) bool {
 	matchesKind := symbol.Kind == js_ast.SymbolHoisted ||
 		symbol.Kind == js_ast.SymbolUnbound
-	return matchesKind && symbol.OriginalName == "exports"
+	return matchesKind && symbol.OriginalName == name
 }
 
 func (r *SnapRenamer) IsExport(ref js_ast.Ref) bool {
 	ref = r.resolveRefFromSymbols(ref)
 	symbol := r.symbols.Get(ref)
-	return r.isExportSymbol(symbol)
-}
-
-func (r *SnapRenamer) isModuleSymbol(symbol *js_ast.Symbol) bool {
-	matchesKind := symbol.Kind == js_ast.SymbolHoisted ||
-		symbol.Kind == js_ast.SymbolUnbound
-	return matchesKind && symbol.OriginalName == "module"
+	return r.isSymbolNamed(symbol, "exports")
 }
 
 func (r *SnapRenamer) IsModule(ref js_ast.Ref) bool {
 	ref = r.resolveRefFromSymbols(ref)
 	symbol := r.symbols.Get(ref)
-	return r.isModuleSymbol(symbol)
+	return r.isSymbolNamed(symbol, "module")
+}
+
+func (r *SnapRenamer) IsRequire(ref js_ast.Ref) bool {
+	ref = r.resolveRefFromSymbols(ref)
+	symbol := r.symbols.Get(ref)
+	return r.isSymbolNamed(symbol, "require")
 }
 
 // NOTE: esbuild renames __dirname/__filename to __dirname2/__filename2 in some cases and


### PR DESCRIPTION
These changes include the version using `ECall` which was necessary when not bundling.
However it was deactivated for now to avoid unnecessary slowdown for something that we don't end up using since we always bundle.