### PR TITLE
thlorenz/feat/require resolve

### DIFF
--- a/internal/snap_api/snap_api_test.go
+++ b/internal/snap_api/snap_api_test.go
@@ -28,7 +28,7 @@ func TestEntryRequiringLocalModule(t *testing.T) {
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
 let oneTwoThree;
 function __get_oneTwoThree__() {
-  return oneTwoThree = oneTwoThree || (require("./foo.js").oneTwoThree)
+  return oneTwoThree = oneTwoThree || (require("./foo", "./foo.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)).oneTwoThree)
 }
   module2.exports = function() {
     get_console().log((__get_oneTwoThree__()));
@@ -66,7 +66,7 @@ __commonJS["./foo.js"] = function(exports, module2, __filename, __dirname, requi
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
 let import_foo;
 function __get_import_foo__() {
-  return import_foo = import_foo || (__toModule(require("./foo.js")))
+  return import_foo = import_foo || (__toModule(require("./foo", "./foo.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname))))
 }
   module2.exports = function() {
     get_console().log((__get_import_foo__()).oneTwoThree);
@@ -94,7 +94,7 @@ module.exports = function () { deprecate() }
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
 let deprecate;
 function __get_deprecate__() {
-  return deprecate = deprecate || (require("./depd.js")("http-errors"))
+  return deprecate = deprecate || (require("./depd", "./depd.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname))("http-errors"))
 }
   module2.exports = function() {
     (__get_deprecate__())();
@@ -122,7 +122,7 @@ __commonJS["./body-parser.js"] = function(exports, module2, __filename, __dirnam
 };`,
 				ProjectBaseDir + "/entry.js": `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
-  require("./body-parser.js");
+  require("./body-parser", "./body-parser.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		},
@@ -170,7 +170,7 @@ require('non-existent')
 			files: map[string]string{
 				ProjectBaseDir + `/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
-  require("non-existent");
+  require("non-existent", "non-existent", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		})
@@ -221,19 +221,19 @@ exports.bar = require('./bar')
 			files: map[string]string{
 				`dev/foo.js`: `
 __commonJS["./foo.js"] = function(exports, module, __filename, __dirname, require) {
-  var fs = require("fs");
+  var fs = require("fs", "fs", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 				`dev/bar.js`: `
 __commonJS["./bar.js"] = function(exports, module2, __filename, __dirname, require) {
 let path;
 function __get_path__() {
-  return path = path || (require("path"))
+  return path = path || (require("path", "path", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)))
 }
 };`,
 				`dev/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
-  Object.defineProperty(exports, "foo", { get: () => require("./foo.js") });
-  Object.defineProperty(exports, "bar", { get: () => require("./bar.js") });
+  Object.defineProperty(exports, "foo", { get: () => require("./foo", "./foo.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)) });
+  Object.defineProperty(exports, "bar", { get: () => require("./bar", "./bar.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)) });
 };`,
 			},
 		},
@@ -260,12 +260,12 @@ exports.fsevents = require('` + ProjectBaseDir + `/node_modules/fsevents/fsevent
 			files: map[string]string{
 				`dev/node_modules/fsevents/fsevents.js`: `
 __commonJS["./node_modules/fsevents/fsevents.js"] = function(exports, module, __filename, __dirname, require) {
-  var Native = require("./node_modules/fsevents/fsevents.node");
+  var Native = require("./node_modules/fsevents/fsevents.node", "./node_modules/fsevents/fsevents.node", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
   var events = Native.constants;
 };`,
 				`dev/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module, __filename, __dirname, require) {
-  exports.fsevents = require("./node_modules/fsevents/fsevents.js");
+  exports.fsevents = require("/dev/node_modules/fsevents/fsevents.js", "./node_modules/fsevents/fsevents.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		},
@@ -296,7 +296,7 @@ __commonJS["./node_modules/fsevents/fsevents.js"] = function(exports, module2, _
 };`,
 				`dev/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
-  exports.fsevents = require("./node_modules/fsevents/fsevents.js");
+  exports.fsevents = require("/dev/node_modules/fsevents/fsevents.js", "./node_modules/fsevents/fsevents.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		},
@@ -328,7 +328,7 @@ __commonJS["./node_modules/file-url.js"] = function(exports, module2, __filename
 };`,
 				`dev/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
-  exports.fileUrl = require("./node_modules/file-url.js");
+  exports.fileUrl = require("/dev/node_modules/file-url.js", "./node_modules/file-url.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		},
@@ -366,8 +366,8 @@ __commonJS["./reassigns-console.js"] = function(exports, module2, __filename, __
 				`dev/entry.js`: `
 __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
   module2.exports = function() {
-    require("./fine.js");
-    require("./reassigns-console.js");
+    require("./fine", "./fine.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
+    require("./reassigns-console", "./reassigns-console.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
   };
 };`,
 			},

--- a/internal/snap_api/snap_api_test.go
+++ b/internal/snap_api/snap_api_test.go
@@ -417,7 +417,7 @@ __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, req
   function toBeResolved(prefix) {
     return prefix + "foo";
   }
-  require.resolve(toBeResolved("./"), (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname);
+  require.resolve(toBeResolved("./"), (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname));
 };`,
 			},
 		},

--- a/internal/snap_printer/snap_handle_ecall.go
+++ b/internal/snap_printer/snap_handle_ecall.go
@@ -1,0 +1,44 @@
+package snap_printer
+
+import "github.com/evanw/esbuild/internal/js_ast"
+
+// require.resolve
+func (p *printer) handleRequireResolve(ecall *js_ast.ECall) (handled bool) {
+	switch tgt := ecall.Target.Data.(type) {
+	case *js_ast.EDot:
+		if tgt.Name != "resolve" {
+			return false
+		}
+		// Ensure it is a `require.resolve`
+		switch reqTgt := tgt.Target.Data.(type) {
+		case *js_ast.EIdentifier:
+			if p.renamer.IsRequire(reqTgt.Ref) {
+				// Cannot rewrite non-custom require.resolve
+				if len(ecall.Args) > 1 {
+					return false
+				}
+				p._printRequireResolve(&ecall.Args[0])
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// NOTE: currently not used as when bundling the ERequireResolve case is hit instead
+func (p *printer) handleECall(ecall *js_ast.ECall) (handled bool) {
+	return p.handleRequireResolve(ecall)
+}
+
+// -----------------
+// Printers
+// -----------------
+
+func (p *printer) _printRequireResolve(request *js_ast.Expr) {
+	p.print("require.resolve(")
+	p.printExpr(*request, js_ast.LComma, 0)
+	// NOTE: more info about __dirname2/__dirname inside
+	// internal/snap_renamer/snap_renamer.go (functionWrapperForAbsPath)
+	p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
+	p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
+}

--- a/internal/snap_printer/snap_handle_ecall.go
+++ b/internal/snap_printer/snap_handle_ecall.go
@@ -41,4 +41,5 @@ func (p *printer) _printRequireResolve(request *js_ast.Expr) {
 	// internal/snap_renamer/snap_renamer.go (functionWrapperForAbsPath)
 	p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
 	p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
+	p.print(")")
 }

--- a/internal/snap_printer/snap_printer.go
+++ b/internal/snap_printer/snap_printer.go
@@ -950,7 +950,11 @@ func (p *printer) printRequireOrImportExpr(importRecordIndex uint32, leadingInte
 			p.printSpaceBeforeIdentifier()
 			p.print("require(")
 			p.addSourceMapping(record.Range.Loc)
+			p.printQuotedUTF8(record.Path.Text, true)
+			p.print(", ")
 			p.printQuotedUTF8(p.resolveRequireName(record), true /* allowBacktick */)
+			p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
+			p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
 			p.print(")")
 			return
 		}

--- a/internal/snap_printer/snap_printer.go
+++ b/internal/snap_printer/snap_printer.go
@@ -1205,32 +1205,34 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 			}
 		}
 
-		// We don't ever want to accidentally generate a direct eval expression here
-		p.callTarget = e.Target.Data
-		if !e.IsDirectEval && p.isUnboundEvalIdentifier(e.Target) {
-			if p.options.RemoveWhitespace {
-				p.print("(0,")
+		if handled := p.handleECall(e); !handled {
+			// We don't ever want to accidentally generate a direct eval expression here
+			p.callTarget = e.Target.Data
+			if !e.IsDirectEval && p.isUnboundEvalIdentifier(e.Target) {
+				if p.options.RemoveWhitespace {
+					p.print("(0,")
+				} else {
+					p.print("(0, ")
+				}
+				p.printExpr(e.Target, js_ast.LPostfix, 0)
+				p.print(")")
 			} else {
-				p.print("(0, ")
+				p.printExpr(e.Target, js_ast.LPostfix, targetFlags)
 			}
-			p.printExpr(e.Target, js_ast.LPostfix, 0)
-			p.print(")")
-		} else {
-			p.printExpr(e.Target, js_ast.LPostfix, targetFlags)
-		}
 
-		if e.OptionalChain == js_ast.OptionalChainStart {
-			p.print("?.")
-		}
-		p.print("(")
-		for i, arg := range e.Args {
-			if i != 0 {
-				p.print(",")
-				p.printSpace()
+			if e.OptionalChain == js_ast.OptionalChainStart {
+				p.print("?.")
 			}
-			p.printExpr(arg, js_ast.LComma, 0)
-		}
-		p.print(")")
+			p.print("(")
+			for i, arg := range e.Args {
+				if i != 0 {
+					p.print(",")
+					p.printSpace()
+				}
+				p.printExpr(arg, js_ast.LComma, 0)
+			}
+			p.print(")")
+		} // end handleECall
 
 		if wrap {
 			p.print(")")

--- a/internal/snap_printer/snap_printer.go
+++ b/internal/snap_printer/snap_printer.go
@@ -1227,6 +1227,7 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 			p.printExpr(arg, js_ast.LComma, 0)
 		}
 		p.print(")")
+
 		if wrap {
 			p.print(")")
 		}
@@ -1245,6 +1246,8 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 		p.printSpaceBeforeIdentifier()
 		p.print("require.resolve(")
 		p.printQuotedUTF8(p.importRecords[e.ImportRecordIndex].Path.Text, true /* allowBacktick */)
+		p.print(", (typeof __filename2 !== 'undefined' ? __filename2 : __filename)")
+		p.print(", (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)")
 		p.print(")")
 		if wrap {
 			p.print(")")
@@ -2828,7 +2831,7 @@ func Print(
 ) PrintResult {
 
 	var p *printer
-	var isRenaming bool = false
+	var isRenaming = false
 	switch snapRenamer := r.(type) {
 	case *snap_renamer.SnapRenamer:
 		isRenaming = snapRenamer.IsEnabled

--- a/internal/snap_printer/snap_printer_test.go
+++ b/internal/snap_printer/snap_printer_test.go
@@ -1310,7 +1310,8 @@ module.exports = exports = require("./lib/_stream_readable.js");
 
 func TestDebug(t *testing.T) {
 	debugPrinted(t, `
-const { v4: uuidv4 } = require('uuid')
-var x = uuidv4()
+function runTests() {
+	delete require.cache[require.resolve("./fixtures/sync-deps.js")];
+}
 `, ReplaceAll)
 }

--- a/internal/snap_renamer/snap_renamer.go
+++ b/internal/snap_renamer/snap_renamer.go
@@ -232,31 +232,31 @@ func (r *SnapRenamer) IsUnwrappable(ref js_ast.Ref) bool {
 	if symbol.Kind == js_ast.SymbolUnbound {
 		return true
 	}
-	return r.isExportSymbol(symbol)
+	return r.isSymbolNamed(symbol, "exports")
 }
 
-func (r *SnapRenamer) isExportSymbol(symbol *js_ast.Symbol) bool {
+func (r *SnapRenamer) isSymbolNamed(symbol *js_ast.Symbol, name string) bool {
 	matchesKind := symbol.Kind == js_ast.SymbolHoisted ||
 		symbol.Kind == js_ast.SymbolUnbound
-	return matchesKind && symbol.OriginalName == "exports"
+	return matchesKind && symbol.OriginalName == name
 }
 
 func (r *SnapRenamer) IsExport(ref js_ast.Ref) bool {
 	ref = r.resolveRefFromSymbols(ref)
 	symbol := r.symbols.Get(ref)
-	return r.isExportSymbol(symbol)
-}
-
-func (r *SnapRenamer) isModuleSymbol(symbol *js_ast.Symbol) bool {
-	matchesKind := symbol.Kind == js_ast.SymbolHoisted ||
-		symbol.Kind == js_ast.SymbolUnbound
-	return matchesKind && symbol.OriginalName == "module"
+	return r.isSymbolNamed(symbol, "exports")
 }
 
 func (r *SnapRenamer) IsModule(ref js_ast.Ref) bool {
 	ref = r.resolveRefFromSymbols(ref)
 	symbol := r.symbols.Get(ref)
-	return r.isModuleSymbol(symbol)
+	return r.isSymbolNamed(symbol, "module")
+}
+
+func (r *SnapRenamer) IsRequire(ref js_ast.Ref) bool {
+	ref = r.resolveRefFromSymbols(ref)
+	symbol := r.symbols.Get(ref)
+	return r.isSymbolNamed(symbol, "require")
 }
 
 // NOTE: esbuild renames __dirname/__filename to __dirname2/__filename2 in some cases and


### PR DESCRIPTION
- fix yarn-specific perf regression (#590)
- fix #611: source map size regression
- remove test-only "js_printer.PrintExpr" function
- optimize source map quoting
- publish 0.8.25 to npm
- return an object from "flagsForBuildOptions"
- unshare services with different cwd
- avoid syntax error for newline in path or namespace
- ignore all rimraf errors to fix windows flakes
- add a warning about calling an import namespace
- also warn about constructing import namespaces
- fix #613: imported symbols are side-effect free
- publish 0.8.26 to npm
- fix #626: "import.meta" is supported in node 10.4+
- more detail for undefined import warning (#629)
- add tests for symlinks in the cwd (#627)
- Fix realpath function (#628)
- release notes for #628
- add "--sources-content=false" (#624)
- fix #617: do not export symbols inside cjs wrapper
- use args struct for define implementation
- fix #581, close #582: auto-inject object defines
- publish 0.8.27 to npm
- call out json syntax in define error (#630)
- add "or a single identifier" to message
- remove fusebox benchmarks
- include newer benchmarks in top-level targets
- logger: "Stderr" => "Output"
- fix #631: optionally print a build summary
- reduce name collisions with import namespaces
- fix #604: keep unused imports for svelte
- fix test failure, add more tests
- publish 0.8.28 to npm
- summary table: default to 80 character width
- allow tree shaking unused values of some operators
- move lowering tests to another file
- extract common flags for react admin benchmark
- minify "==" and "!=" inside "!"
- minification: inline single-use variables
- fix auto-formatting issue
- fix transforms duplicating single-use references
- fix #634: use ".._/" for paths outside of outbase
- use "_.._" instead of ".._" for finder (#634)
- minify "!(a, b)" => "a, !b"
- remove unnecessary "fmt.Sprintf" call
- remove trailing continue in loops
- minify: optimize implicit continue
- minify: optimize implicit return
- publish 0.8.29 to npm
- minify: fold expression into switch
- minify: convert "===" to "==" in more cases
- remove "===" if one side is a constant
- use "return" in expression mangling tests
- minify: remove certain operators if unused
- fix "/* @jsx" comments without a trailing space
- remove early-return for unary visitor
- minify: extract the comma operator sometimes
- minify: use left-associativity for "&& || ??"
- simplify linker groups
- remove unused argument
- make file names explicit
- increment "nextSourcesIndex" correctly (#638)
- remove cross-file variable splicing (#638)
- minify: optimize computed string properties
- merge repeated if-jump statements
- publish 0.8.30 to npm
- fix #639: tree-shake unused code with iife format
- fix #648: skip some implicit return optimizations
- fix #650: add "--sourcemap=both"
- publish 0.8.31 to npm
- Allows NodeJS to terminate also if there is an active service. (#656)
- release notes for #656
- update benchmark scripts for latest parcel 2 (#669)
- fix bug in metafile path generation (#662)
- ci fix for paths on windows
- add support for parsing typescript 4.2
- fix #666: scan for "node_modules" in plugin paths
- remove self-assignment warning (#666)
- fix #654: add original error to returned errors
- fix #657: only simplify "?:" when minifying
- fix #655: add "kind" to imports in metafile
- publish 0.8.32 to npm
- update parcel again to fix source maps (#669)
- fix #669: update parcel 2 benchmark image
- fix incremental build regression due to #656
- fix the 2+ rebuild case
- fix #616: make js api minification optional
- Move sourcesContent to common flags in JS API (#683)
- release notes for #683
- update webpack 5 benchmark (#681)
- fix #678: insert object spread shim after super()
- fix #674: add "--platform=neutral"
- publish 0.8.33 to npm
- fix #686: add more info for invalid path error
- fix missing 'neutral' in platform description (#695)
- fix missing "neutral" in help text (#695)
- fix #701: parser bug with arrow functions
- publish 0.8.34 to npm
- add package-lock.json for benchmark packages
- update benchmark image in readme (#681)
- link to plugin docs in readme
- disallow the "await x ** 2" edge case
- fix #702: add support for namespaces in jsx
- fix "worker: false" in browser wasm shim
- browser: use getters to avoid deprecation warning
- hack: speed up "esbuild-wasm" despite node bug
- ci: pin the go version used for testing
- fix stdin with wasm on windows (#687)
- rename "fs_" => "modkey_"
- split fs.go into separate files
- fs: abstract out stat call
- fix #687: purge all uses of "path/filepath"
- hack around node windows unicode bug (#687)
- add a test to verify that #693 is fixed
- publish 0.8.35 to npm
- fix regression due to commit 93423e52
- hide the *.node files from yarn
- publish 0.8.36 to npm
- move "exit0.js" out of the "bin" directory
- reorder version in help text
- update go 1.15.5 => go 1.15.7
- run "make compat-table" again
- improve ambiguous import errors (#723)
- fix #723: multi-level re-export shadowing
- allow ambiguous star imports (#723)
- esbuild-wasm: don't create a new exit0 native module for each run (#719)
- release notes for #719
- fix serve with outfile (#707)
- warn about duplicate object literal keys
- remove duplicate keys from metafile
- release notes about go upgrade
- add "inputs" to "file" loader metadata
- fix #726: imports+exports for all metafile outputs
- slight change to log format
- publish 0.8.37 to npm
- add "pluginData" to pass data between plugins (#696)
- service: factor out plugin conversion
- service: factor out http serve
- fix #21: implement a basic polling watch mode
- publish 0.8.38 to npm
- simplify reference count tracking
- fix #689 and #730: add cwd option, disable service stop()
- fix #643: child process doesn't exit
- add a further guard against #643
- better formatting for stdin plugin tests
- publish 0.8.39 to npm
- resolve "browser" keys without extensions (#740)
- commit automatic change that npm v7 keeps making
- mention npm v7 bug in bin fallback (#462)
- fix #734: ts decorators on class ctor args
- publish 0.8.40 to npm
- fix #749: forbid some syntax with "esm" format
- basic propagation of "use strict"
- keep all identifiers in "with" statements
- bug fix: `use strict` is not a directive
- skip comments when checking that "use strict" is first
- fix #750: enable gc for watch mode
- strict mode hoisting of block-level functions
- strict mode: reject for-in var initializers
- strict mode: cannot assign to "eval" and "arguments"
- "import()" does not mean the "esm" format
- fix for rest arguments with initializers
- strict mode: cannot declare "eval" or "arguments"
- ES5 fix for uglify tests
- strict mode: forbid duplicate argument names
- publish 0.8.41 to npm
- duplicate key warning: show original key
- fix #755: crash with "--keep-names"
- strict mode: disallow reserved words
- strict mode: forbid legacy octal literals
- fix #752: basic support for watch mode with plugins
- fix #745: add "errors" and "warnings" to errors
- attempt to make tests more robust
- work around unfortunate windows ci limiations
- publish 0.8.42 to npm
- fix #757: use XDG_CACHE_HOME in install script
- infer boolean and null/undef with side effects
- fix #765: many additional true/false dce cases
- more simplification of unused expressions
- fix #760: verbatim whitespace for css variables
- small fixes for css minification
- fix #766: support recursive symlinks in resolver
- ts "export =" syntax is not esm syntax
- ts "import id =" syntax is not esm syntax
- fix #758: subtle circular dependency issue
- add .DS_Store to .gitignore
- add support for "NODE_PATH"
- publish 0.8.43 to npm
- fix strict mode handling of for-in variable initializers
- always transform away for-in variable initializers
- add message notes to the api
- finish the bundler var relocation pass
- fix #61: add a logo
- add logo to release notes
- fix #776: skip over leading BOM in CSS files
- add png version of logo (#61)
- fix #780: add origin information to errors from plugins
- fix #784: only ping the host in async apis
- move some options to advanced help text section
- fix #781: add a "--preserve-symlinks" flag
- suggest default import when calling import ns
- fix #785: avoid absolute paths for disabled files
- publish 0.8.44 to npm
- fix #786: avoid absolute paths for disabled modules (#787)
- release notes for #786
- fix #792: resolve absolute paths in tsconfig.json
- remove watch mode feedback
- still start watch mode if there are errors
- fix #793: change watch mode output
- add header to serve dir listing
- serve: redirect to slash for directories
- fix #796: add the "--servedir=" flag
- fix EISDIR not working on windows
- serve: do not cache directory listings
- publish 0.8.45 to npm
- fix #804: minify of ".0" in css
- run "make compat-table"
- serve: support range requests
- publish 0.8.46 to npm
- limit the height of the summary table
- apply error limit to warnings too
- ignore U+FEFF in terminal width total
- validation of certain css at-rules
- help text: public => www
- Stop indirect call warning for 'require.cache' for CommonJS modules (#813)
- add contributed to readme
- Add two test cases for tsx and generics interaction. (#825)
- fix comments (#813)
- fix #826: sometimes ignore path query part
- fix #822: "/..." paths are absolute on windows
- warn about issues with case-sensitive paths
- omit case warning inside "node_modules"
- Fix broken link to API docs in npm README (#830)
- fix another broken link in npm readme
- Add native builds for ARM-based Macs (#820)
- release notes for #820
- fix go version check
- publish 0.8.47 to npm
- allow "in" inside template inside "for" (#835)
- forbid newline after "async" in "async<T>()=>{}"
- fix "async" inside "new" (#835)
- forbid "let" starting a for-of loop initializer
- allow "," after spread in destructuring (#835)
- allow "super" in constructor args (#835)
- fix #835: allow "arguments" in computed class fields
- forbid function decls inside if in strict mode
- cannot re-declare lexical functions in blocks
- remove local server from wasm package (#836)
- forbid legacy octal escapes in some places
- support "use strict" after other directives
- "\8" and "\9" count as legacy octal escapes
- license comment should not disable "use strict"
- forbid "use strict" with non-simple parameter list
- optional chain cannot be template literal tag
- all code inside a class is strict mode
- no duplicate binding names in a parameter list
- "UniqueFormalParameters" for arrows and methods
- "([])" and "({})" are not valid assignment targets
- forbid "eval" and "arguments" as function names
- forbid "({yield})" and "({await})"
- handle newline after "async" in method
- duplicate arg checks "use strict" in body
- "\08" is invalid while "\0" is valid
- fix a test that must be run in esm mode
- respect "keep_fnames" in terser tests
- publish 0.8.48 to npm
- fix #816: treat ENOTDIR as ENOENT for directories
- unify import namespace warnings
- fix #842: include known globals for the browser
- pass "-s -w" to go linker, removes 0.1mb (#836)
- fix #844: edge case where return should cause dead code
- fix #846: remove speculative errors from log
- fix #834: add Go "ParseServeOptions" API
- publish 0.8.49 to npm
- drop 0.4mb "runtime/pprof" and "runtime/trace" (#836)
- introduce "ast.Index32"
- use "ast.Index32" somewhere else too
- direct "eval" implies "module" and "exports"
- direct "eval" only does this when bundling
- fix #856: remove "use asm" directives
- fix #857: more hoisting edge cases
- fix windows ci issue
- Fix: css empty rulesets should be removed (#851)
- fixes after landing css change
- publish 0.8.50 to npm
- specific error about missing loader
- css printer: make options explicit
- css: pretty-print long lists in declarations
- fix #865: include line/column in first line of logs
- allow "--define" with "import.meta"
- Fix data race: collect results, then append. (#872)
- add release notes for #871
- add "-race" to "go test" (#872)
- serve: print ":::8000" as "[::]:8000"
- support "--serve=[::]:8000" for ipv6
- fix #866: default serve host to "0.0.0.0"
- fix "0.0.0.0" in tests
- fix "0.0.0.0" in "node unref" test
- fix #862: resolve absolute paths
- generate source mapping at block starts (#870)
- fix source maps for lowered classes
- entryPoint information in metafile (#811)
- fixes for the "entryPoint" property feature (#711)
- publish 0.8.51 to npm
- "repr" => "chunkRepr"
- fix #878: concurrent map write with inject
- fix #874: update version.go atomically
- fix #879: provide "kind" to "onResolve" plugins
- bad vscode, no tabs
- make the typescript compiler happy
- Add ESBUILD_BIN_PATH (#881)
- "ESBUILD_BIN_PATH" => "ESBUILD_BINARY_PATH"
- publish 0.8.52 to npm
- use different name for class shadow symbol
- fix #885: "this" in class static fields
- fix "this" inside computed class fields
- remove support for "@namespace"
- fix #888: add path templates for chunks and assets
- fix #893: add the "import().catch()" pattern
- publish 0.8.53 to npm
- fix #901: private class method ordering
- fix "--keep-names" for private class members
- fix #899: cross-chunk import paths
- don't assume direct eval can access imports
- warn about direct "eval" in an esm file
- ci: import relative path to work around windows
- publish 0.8.54 to npm
- fix #910: esm "export {}" must still use cjs "exports"
- avoid changing "this" for imported function calls
- fix #532: use node's "default" semantics for cjs-in-esm
- mix babel and node semantics for "default" (#532)
- publish 0.8.55 to npm
- fix #914: work around jest breaking node buffers
- flush deferred warnings before writing to stdout
- fix #913: tsconfig "baseUrl" override of "paths"
- treat file w/ TLA but w/o import/export as ESM
- treat "index.js" as "main" in "package.json"
- publish 0.8.56 to npm
- test "--keep-names" against node's behavior
- test "--keep-names" with property assignments
- fix class fields with "keep names"
- fix #926: use "--target=node10" for node code in npm
- only compute hash if "[hash]" is present
- fix #928: no longer use a content hash for chunks
- top-level for-await causes strict mode
- support percent-escaped sourceMappingURL comments
- support data url imports in js and css
- fix "+" characters in data URLs
- publish 0.8.57 to npm
- plugins: do not truncate stack traces
- plugins: on error, say what triggered the plugin
- add imported file name to missing export error
- plugins: support error locations in constructors
- remove the deprecated "avoid TDZ" option
- remove unused "SpinnerBusy" and "SpinnerIdle"
- single-line to multi-line build calls
- remove "--summary", always print summary instead
- remove the "startService" API
- types: consolidate the "ImportKind" type
- enforce that "transform" input is a string
- add node unref tests to common tests
- remove "startService" in unref tests
- fix typescript type error
- avoid run time in summary for yarn 1
- remove "startService" from uglify and terser tests
- make banner and footer also work for css
- ".mjs" and ".cjs" are no longer implied
- avoid printing the summary in certain cases
- move package.json code to separate file
- implement the package.json "exports" field
- implement conditions for the "exports" field
- some more "exports" tests
- update readme for the "exports" feature
- implement custom conditions for "exports"
- fix "try.html"
- remove "metafile" from "outputFiles"
- data loaders from plugins are not side-effect free
- rename "error limit" to "log limit"
- fix js target affecting css
- have the js API write to stdout by default
- reorganize release notes
- mark issues as fixed: fix #633, fix #187, fix #712, fix #704
- support implicit extensions with "exports"
- publish 0.9.0 to npm
- looks like npm broke their doc links recently
- Fix metafile changelog entry (#940)
- Bound stdout shifting to prevent excessive allocations (#941)
- pretend that inaccessible directories are empty (#942)
- initial support for conditional css imports (#953)
- link to #941 in the release notes
- fix #951: lower object rest and spread for v8
- add optional mutation to value capture
- fix #956: preserve the value of object rest assign
- fix #955: support css page margin rules
- css empty rule removal should happen in parser
- avoid using the alias "*" for namespace objects
- add annotations for "cjs-module-lexer" and node
- publish 0.9.1 to npm
- fix #960: avoid keywords in export name annotations
- map to "null" instead of "0" to fix "cjs-module-lexer"
- publish 0.9.2 to npm
- Avoid stdout buffer allocation (#967)
- improve error messages for "exports" path resolve
- introduce "peDebug" struct
- improve "exports" error messages
- compat table: use the maximum across all subtests
- mention glob syntax in entry point errors (#976)
- fix #975: add target env to lowering error
- add engine-to-string to compat-table.js
- fix comments (#983)
- fix "exports" path resolution for scoped packages
- serve tests: 127.0.0.1 to avoid mac firewall popup
- utf16 bug in outside-file line/column accounting
- publish 0.9.3 to npm
- fix typo (#987)
- treat "ERROR_INVALID_NAME" as "ENOENT" on windows (#994)
- "node-unref-tests" depends on "scripts/node_modules"
- upgrade from go 1.16.0 to go 1.16.2 (#996)
- move the unrelated "Joiner" out of "js_printer"
- fix source mappings for external import paths
- remove unused unicode library in tests (#1004)
- fix #997: do not warn about "@-ms-viewport" in css
- enable hashes in entry file paths (#1001)
- attempt to fix pnpm hard link issues (#970)
- fix #999: no "sideEffects" warn in "node_modules"
- fix #979: call "initialize" in node to warm up
- update to "@unicode/unicode-13.0.0" (#1007)
- publish 0.9.4 to npm
- fix #1013: parsing for the "[dir]" placeholder
- publish 0.9.5 to npm
- fix #1016: parse issue with ts arrow return types
- fix stack parsing to skip internal "node:" lines
- do not use `Object.assign` for object spread (#1018)
- re-enable the "worker_threads" sync workaround (#1021)
- implement recent v8 changes to optional chaining behavior (#1022)
- fix #373: expose build options to plugins
- publish 0.9.6 to npm
- forbid top-level returns in ESM
- fix browser test
- fix #1030: work around a bug in go's mime types
- fix #1039: lazily capture plugin register traces
- fix comments (#1046)
- fix #803: add support for android arm64
- publish 0.9.7 to npm
- use windows-proof mime type for "file" loader too
- Add Source Map sourceRoot Support (#1028)
- update after landing #1028
- add "watchFiles" and "watchDirs"
- Avoid a buffer copy when decoding utf-8 in node 10 (#1054)
- remove support for "module" and "exports" in esm
- all non-entry cjs files get wrapped
- "cjsStyleExports" => "ExportsKind"
- do not change "import()" to "require()"
- change "cjsWrap" into an enum
- "export * as" is no longer implemented using cjs
- basic support of top-level await
- shorten commonjs helper
- change esm/cjs support: "type" and "default"
- publish 0.10.0 to npm
- fix #1057: pass "metafile" to "onRebuild"
- small refactor to log formatting
- add "suggestion" to log message location
- fix #1058: add the "formatMessages" api
- fix "ESBUILD_WORKER_THREADS" difference
- test: use ".cjs" to guard against "type": "module"
- fix incorrect import reference
- relocate entry point export code
- fix colors in summary
- fix changelog whoops
- fix #998: remove the file splitting optimization
- skip computing unnecessary hashes
- publish 0.10.1 to npm
- fix #1064: crash with css + js + code splitting
- fix #1066: private fields inside destructuring
- separate out js and css chunk keys
- fix name collision with esm and direct eval
- publish 0.10.2 to npm
- use "formatMessages" in try.html
- clean up chunk-relative paths with public path
- Add warning when writing to private method (#1067)
- release notes for #1067
- show snapshot test diffs in color
- Fix variable name for terminal colors used in Windows logger (#1074)
- remove unused cross-chunk assignment links
- add relative outbase test
- add implicit outbase test
- fix summary order in the same directory
- ci: node 12 => 14
- merge typescript type prefix and suffix parsing
- fix some typescript type parsing edge cases
- further typescript type parser fixes
- implement lazy evaluation of esm code
- dynamic imports now use the chunk name template
- implement custom output paths for entry points
- output paths now use pre-resolved path
- use the file namespace for file entry points
- add extensions to custom output paths for css
- publish 0.11.0 to npm
- add the "[type]" path template placeholder
- Revert "add the "[type]" path template placeholder"
- fix #1082: missing space before "Promise" when minifying
- fix #1080: omit esm wrapper calls for dead files
- allow top-level await in chrome 89 and node 14.8
- fix #1084: lower "import()" for older targets
- publish 0.11.1 to npm
- fix #1086: add graph edge for wrapped esm import
- need to await async entry point esm wrappers
- fix test non-determinism issue
- add another graph edge for "__exportStar"
- publish 0.11.2 to npm
- auto-define "process.env.NODE_ENV" for the browser
- get rid of go-staticcheck warnings
- remove field "hasErrors" in linker
- rename "fileMeta" => "jsMeta"
- print new snapshots in green
- remove the now-unused "IsAssigned" field
- add a graph debugger
- rename "partRef" => "nonLocalDependency"
- rename "importToBind" => "importData"
- dark mode for graph debugger
- track and retain intermediate re-exporting files (#1100)
- merge "localDependencies" + "nonLocalDependencies"
- add a "debug" log level
- insert "resolverQuery" for resolver internals
- add debug logging to resolver
- add basic bracketing of bundle phases
- release notes for "debug" log level
- publish 0.11.3 to npm
- remove an extra "s"
- Avoid using the same helper function names as TypeScript (#1103)
- guard against overwritten object rest initializer
- fix #1099: always hash all chunk contents
- publish 0.11.4 to npm
- support TS 4.3 `override` syntax (#1105)
- release notes for #1105
- attempt to improve file sort determinism (#1075)
- another file sort determinism change (#1075)
- pull out service members into locals
- use named arguments for "formatMessages"
- use named arguments for "transform"
- use named arguments for "build" and "serve"
- support async plugin "setup" (#111)
- upgrade to go 1.16.3 (#1106)
- rename "outer index" => "source index"
- avoid double-counting each chunk's hash
- speedup: hash in parallel to skip cost if unused
- use xxHash instead of SHA1 for speed (#1107)
- release notes for hashing speedups
- move bit set to another file
- disable tree shaking when using code splitting (#1110)
- publish 0.11.5 to npm
- core: js_ast adding refs needed to snapshot
- core: js_parser updated to support snapshot printing
- core: runtime adding SnapshotSource runtime option
- core: js_printer snapshot related options
- core: bundler updates to support snapshot printing
- core: pgk/api updates to support snapshot printing
- core: adding cmd/snapshot and related make task
- core: update gomod to include godebug
- core: config adding snapshot fields
- core: resolver disabling package.json export field resolution when snapshotting
- core: resolver hacking around safefs version resolution issue
- core: fs allowing mockFS.WachData calls during tests
- snap: adding snap api,printer and renamer including tests
- snap: api test verifies nested vars not relocated
- snap: printer handles replaced vars indexed into
- snap: handling late var declares
- snap: test utils adding option to debug/verify fixtures
- snap: no longer deferring access to `Object`
- snap: api support for norewrite option
- snap: api integrating norewrite functionality
- snap: cleanup commands and make task
- snap: norewrite use snap printer which omits rewrites
- snap: supporting regex for norewrite args
- snap: printer norewrite fixes and test
- snap: api send result via stdout
- snap: fixing print of multi arg require call invocation
- snap: verifying print by default but not panicking
- snap: adding fundamental objects and numbers + dates to valid globals
- snap: printer detects indexed reference to deferred
- snap: snap api treating native modules as externals
- snap: api test for native module require rewrite
- snap: api/cmd rejecting AST on __dirname or __filename use
- snap: api testing updated error handling
- snap: integrating improved AST reject errors
- snap: api sends proper JSON formatted warnings via stdout
- snap: restoring globals for files we don't rewrite
- snap: renamer/printer selectively rewriting globals
- snap: fixing global renaming by not relying on `equals`
- snap: making content pretty printing toggleable
- snap: printer handling aliasing destructuring require
- snap: adding more context as to why externalizing bluebird
- snap: rewriting __dirname/__filename accesses into wrapper
- test: remove late declare fixture test
- snap: cmd update options to latest
- snap: api update options in test to latest
- snap: renamer update symbol and ref resolution to API
- snap: printer update symbol and ref resolution to API
- snap: overwriting snap_printer with v0.11.5 js_printer
- snap: reapplying snap_printer changes to v0.11.5 js_printer
- snap: printer fix require name resolution
- snap: update api tests
- snap: printer always writes `require` statements
- snap: removing obsolete fixtures
- snap: cleaning up TODOs
- snap: api adapting metafile opts and inclusion in return val
- snap: adapting tests to latest changes
- chore: remove github workflows
- snap: added validator which detects function overrides on process
- snap: testing that validation errors are included in printer result
- snap: testing that API properly logs validation errors as warnings
- snap: invalidating buffer property probing
- snap: api reporting defer validation error as CACHE_FAILURE
- snap: improved reporting of global entity probing
- snap: rewrite static errors to throw at runtime
- snap: api adding `--doctor` flag
- snap: printer validates strict when `--doctor` is set
- snap: printer prevents recursive calls for simple cases
- snap: invalidating globals probing in `if` condition
- snap: printer handles two in one assignments
- snap: not rewriting module.exports, exports require assignments
- snap: api sourcemap option includes sourcemap in extra outfile
- snap: cmd set sourcemap option
- chore: separate makefile for snapshot
- chore: excluding snap-platform-darwin-arm64 from build and publish
- chore: separate version for snapshot
- chore: add snapbuild npm packages
- chore: requiring latest stable Go version
- snap: forcing windows paths to forward slashes for results
- chore: npm packages with fixes for windows
- chore: update snapbuild npm versions
- snap: api trimming quotes to fix --defer, --norewrite on windows
- chore: update snapbuild npm versions
- snap: working around sourcemap related crash in printer
- chore: update snapbuild npm versions
- core: resolver exposing snapshot abs dir
- core: bundler including resolved paths with metadata
- chore: update snapbuild npm versions
- core: bundler fixing resolver map paths on windows
- chore: update snapbuild npm versions
- feat: including relative filename and dirname with `require.resolve. (#1)
- snap: printer adapts `require` to include filename, dirname
- core: resolver workaround istextorbinary issue
- snap: adapt snap_api tests to extra `require` args
- snap: printer handles `require.resolve` as `ECall`
- snap: printer fix missing `)` for `ECall` handled `require.resolve`
