### PR TITLE
fix: properly defer import references

### DIFF
--- a/internal/snap_api/snap_api_test.go
+++ b/internal/snap_api/snap_api_test.go
@@ -44,6 +44,74 @@ __commonJS["./foo.js"] = function(exports, module2, __filename, __dirname, requi
 	)
 }
 
+func TestTypeScriptImportingDefaultModule(t *testing.T) {
+	snapApiSuite.expectBuild(t, built{
+		files: map[string]string{
+			ProjectBaseDir + "/entry.js": `
+				import Debug from './debug'
+				const debug = Debug('foo')
+			`,
+			ProjectBaseDir + "/debug.js": `module.exports = function () {}`,
+		},
+		entryPoints: []string{ProjectBaseDir + "/entry.js"},
+	},
+		buildResult{
+			files: map[string]string{
+				ProjectBaseDir + "/debug.js": `
+__commonJS["./debug.js"] = function(exports, module2, __filename, __dirname, require) {
+  module2.exports = function() {
+  };
+};`,
+				ProjectBaseDir + "/entry.js": `
+__commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
+let import_debug;
+function __get_import_debug__() {
+  return import_debug = import_debug || (__toModule(require("./debug", "./debug.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname))))
+}
+let debug;
+function __get_debug__() {
+  return debug = debug || ((0, (__get_import_debug__()).default)("foo"))
+}
+};`,
+			},
+		},
+	)
+}
+
+func TestJavaScriptRequiringDefaultModule(t *testing.T) {
+	snapApiSuite.expectBuild(t, built{
+		files: map[string]string{
+			ProjectBaseDir + "/entry.js": `
+				const Debug = require('./debug')
+				const debug = Debug('foo')
+			`,
+			ProjectBaseDir + "/debug.js": `module.exports = function () {}`,
+		},
+		entryPoints: []string{ProjectBaseDir + "/entry.js"},
+	},
+		buildResult{
+			files: map[string]string{
+				ProjectBaseDir + "/debug.js": `
+__commonJS["./debug.js"] = function(exports, module2, __filename, __dirname, require) {
+  module2.exports = function() {
+  };
+};`,
+				ProjectBaseDir + "/entry.js": `
+__commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, require) {
+let Debug;
+function __get_Debug__() {
+  return Debug = Debug || (require("./debug", "./debug.js", (typeof __filename2 !== 'undefined' ? __filename2 : __filename), (typeof __dirname2 !== 'undefined' ? __dirname2 : __dirname)))
+}
+let debug;
+function __get_debug__() {
+  return debug = debug || ((__get_Debug__())("foo"))
+}
+};`,
+			},
+		},
+	)
+}
+
 func TestEntryImportingLocalModule(t *testing.T) {
 	snapApiSuite.expectBuild(t, built{
 		files: map[string]string{

--- a/internal/snap_printer/snap_printer_common.go
+++ b/internal/snap_printer/snap_printer_common.go
@@ -313,6 +313,20 @@ func (p *printer) expressionHasRequireOrGlobalReference(expr *js_ast.Expr) bool 
 	}
 
 	switch x := expr.Data.(type) {
+	case *js_ast.EImportIdentifier:
+		ref := js_ast.FollowSymbols(p.symbols, x.Ref)
+		symbol := p.symbols.Get(ref)
+		refToCheck := x.Ref
+		if symbol.NamespaceAlias != nil {
+			refToCheck = symbol.NamespaceAlias.NamespaceRef
+		}
+		if p.renamer.HasBeenReplaced(refToCheck) {
+			return true
+		}
+		if p.renamer.GlobalNeedsDefer(refToCheck) {
+			return true
+		}
+		return false
 	case *js_ast.EIdentifier:
 		if p.renamer.HasBeenReplaced(x.Ref) {
 			return true


### PR DESCRIPTION
There was a scenario that was left out when deferring loading of modules. Specifically, import references were not getting properly deferred. To fix this, we'll see if an import reference was involved in a replacement and if so, go ahead and defer it. This logic is very similar to what happens with require statements.