### PR TITLE
fix: issue with dependencies not properly being marked as deferred

### DIFF
--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3434,6 +3434,7 @@ func (c *linkerContext) convertStmtsForChunk(sourceIndex uint32, stmtList *stmtL
 				// Be careful to not modify the original statement
 				clone := *s
 				clone.IsExport = false
+				clone.IsStrippedExport = true
 				stmt.Data = &clone
 			}
 

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1021,7 +1021,7 @@ type SNamespace struct {
 }
 
 type SFunction struct {
-	Fn        Fn
+	Fn       Fn
 	IsExport bool
 }
 

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1021,8 +1021,8 @@ type SNamespace struct {
 }
 
 type SFunction struct {
-	Fn               Fn
-	IsExport         bool
+	Fn        Fn
+	IsExport bool
 }
 
 type SClass struct {

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1021,13 +1021,13 @@ type SNamespace struct {
 }
 
 type SFunction struct {
-	Fn       Fn
-	IsExport bool
+	Fn               Fn
+	IsExport         bool
 }
 
 type SClass struct {
-	Class    Class
-	IsExport bool
+	Class            Class
+	IsExport         bool
 }
 
 type SLabel struct {
@@ -1149,9 +1149,10 @@ const (
 )
 
 type SLocal struct {
-	Decls    []Decl
-	Kind     LocalKind
-	IsExport bool
+	Decls            []Decl
+	Kind             LocalKind
+	IsExport         bool
+	IsStrippedExport bool
 
 	// The TypeScript compiler doesn't generate code for "import foo = bar"
 	// statements where the import is never used.

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1026,8 +1026,8 @@ type SFunction struct {
 }
 
 type SClass struct {
-	Class            Class
-	IsExport         bool
+	Class    Class
+	IsExport bool
 }
 
 type SLabel struct {

--- a/internal/snap_api/snap_api_test.go
+++ b/internal/snap_api/snap_api_test.go
@@ -491,6 +491,31 @@ __commonJS["./entry.js"] = function(exports, module2, __filename, __dirname, req
 		},
 	)
 }
+
+func TestExportDeferredLocalVar(t *testing.T) {
+	snapApiSuite.expectBuild(t, built{
+		files: map[string]string{
+			ProjectBaseDir + "/entry.js": `
+export const cwd = process.cwd()
+`,
+		},
+		entryPoints: []string{ProjectBaseDir + "/entry.js"},
+	},
+		buildResult{
+			files: map[string]string{
+				`dev/entry.js`: `
+__commonJS["./entry.js"] = function(exports, module, __filename, __dirname, require) {
+  __markAsModule(exports);
+  __export(exports, {
+    cwd: () => cwd
+  });
+  var cwd = get_process().cwd();
+};`,
+			},
+		},
+	)
+}
+
 func TestDebug(t *testing.T) {
 	snapApiSuite.debugBuild(t, built{
 		files: map[string]string{

--- a/internal/snap_printer/snap_handle_slocal.go
+++ b/internal/snap_printer/snap_handle_slocal.go
@@ -2,9 +2,10 @@ package snap_printer
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/evanw/esbuild/internal/js_ast"
 	"github.com/evanw/esbuild/internal/snap_renamer"
-	"strings"
 )
 
 //
@@ -82,7 +83,7 @@ func (p *printer) extractDeclarations(local *js_ast.SLocal) []MaybeRequireDecl {
 	case js_ast.LocalConst,
 		js_ast.LocalLet,
 		js_ast.LocalVar:
-		if !local.IsExport {
+		if !local.IsExport && !local.IsStrippedExport {
 			for _, decl := range local.Decls {
 				require, isRequire := p.extractRequireDeclaration(decl)
 				if isRequire {


### PR DESCRIPTION
The issue here is that local variables that were using features that needed to be deferred and were exported using `export <const|let|var> <name>` syntax were not properly flagging the dependency as needing to be deferred. This change will ensure that the "needs deferred" code gets executed on import and will flag the dependency appropriately.